### PR TITLE
Usb cdc

### DIFF
--- a/targets/stm32l442/lib/usbd/usbd_cdc.c
+++ b/targets/stm32l442/lib/usbd/usbd_cdc.c
@@ -1,0 +1,977 @@
+/**
+  ******************************************************************************
+  * @file    usbd_cdc.c
+  * @author  MCD Application Team
+  * @brief   This file provides the high layer firmware functions to manage the
+  *          following functionalities of the USB CDC Class:
+  *           - Initialization and Configuration of high and low layer
+  *           - Enumeration as CDC Device (and enumeration for each implemented memory interface)
+  *           - OUT/IN data transfer
+  *           - Command IN transfer (class requests management)
+  *           - Error management
+  *
+  *  @verbatim
+  *
+  *          ===================================================================
+  *                                CDC Class Driver Description
+  *          ===================================================================
+  *           This driver manages the "Universal Serial Bus Class Definitions for Communications Devices
+  *           Revision 1.2 November 16, 2007" and the sub-protocol specification of "Universal Serial Bus
+  *           Communications Class Subclass Specification for PSTN Devices Revision 1.2 February 9, 2007"
+  *           This driver implements the following aspects of the specification:
+  *             - Device descriptor management
+  *             - Configuration descriptor management
+  *             - Enumeration as CDC device with 2 data endpoints (IN and OUT) and 1 command endpoint (IN)
+  *             - Requests management (as described in section 6.2 in specification)
+  *             - Abstract Control Model compliant
+  *             - Union Functional collection (using 1 IN endpoint for control)
+  *             - Data interface class
+  *
+  *           These aspects may be enriched or modified for a specific user application.
+  *
+  *            This driver doesn't implement the following aspects of the specification
+  *            (but it is possible to manage these features with some modifications on this driver):
+  *             - Any class-specific aspect relative to communication classes should be managed by user application.
+  *             - All communication classes other than PSTN are not managed
+  *
+  *  @endverbatim
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2017 STMicroelectronics International N.V.
+  * All rights reserved.</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without
+  * modification, are permitted, provided that the following conditions are met:
+  *
+  * 1. Redistribution of source code must retain the above copyright notice,
+  *    this list of conditions and the following disclaimer.
+  * 2. Redistributions in binary form must reproduce the above copyright notice,
+  *    this list of conditions and the following disclaimer in the documentation
+  *    and/or other materials provided with the distribution.
+  * 3. Neither the name of STMicroelectronics nor the names of other
+  *    contributors to this software may be used to endorse or promote products
+  *    derived from this software without specific written permission.
+  * 4. This software, including modifications and/or derivative works of this
+  *    software, must execute solely and exclusively on microcontroller or
+  *    microprocessor devices manufactured by or for STMicroelectronics.
+  * 5. Redistribution and use of this software other than as permitted under
+  *    this license is void and will automatically terminate your rights under
+  *    this license.
+  *
+  * THIS SOFTWARE IS PROVIDED BY STMICROELECTRONICS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS, IMPLIED OR STATUTORY WARRANTIES, INCLUDING, BUT NOT
+  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  * PARTICULAR PURPOSE AND NON-INFRINGEMENT OF THIRD PARTY INTELLECTUAL PROPERTY
+  * RIGHTS ARE DISCLAIMED TO THE FULLEST EXTENT PERMITTED BY LAW. IN NO EVENT
+  * SHALL STMICROELECTRONICS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+  * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+  * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+  * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+  /* BSPDependencies
+  - "stm32xxxxx_{eval}{discovery}{nucleo_144}.c"
+  - "stm32xxxxx_{eval}{discovery}_io.c"
+  EndBSPDependencies */
+
+/* Includes ------------------------------------------------------------------*/
+#include "usbd_cdc.h"
+#include "usbd_ctlreq.h"
+
+
+/** @addtogroup STM32_USB_DEVICE_LIBRARY
+  * @{
+  */
+
+
+/** @defgroup USBD_CDC
+  * @brief usbd core module
+  * @{
+  */
+
+/** @defgroup USBD_CDC_Private_TypesDefinitions
+  * @{
+  */
+/**
+  * @}
+  */
+
+
+/** @defgroup USBD_CDC_Private_Defines
+  * @{
+  */
+/**
+  * @}
+  */
+
+
+/** @defgroup USBD_CDC_Private_Macros
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+
+/** @defgroup USBD_CDC_Private_FunctionPrototypes
+  * @{
+  */
+
+
+static uint8_t  USBD_CDC_Init (USBD_HandleTypeDef *pdev,
+                               uint8_t cfgidx);
+
+static uint8_t  USBD_CDC_DeInit (USBD_HandleTypeDef *pdev,
+                                 uint8_t cfgidx);
+
+static uint8_t  USBD_CDC_Setup (USBD_HandleTypeDef *pdev,
+                                USBD_SetupReqTypedef *req);
+
+static uint8_t  USBD_CDC_DataIn (USBD_HandleTypeDef *pdev,
+                                 uint8_t epnum);
+
+static uint8_t  USBD_CDC_DataOut (USBD_HandleTypeDef *pdev,
+                                 uint8_t epnum);
+
+static uint8_t  USBD_CDC_EP0_RxReady (USBD_HandleTypeDef *pdev);
+
+static uint8_t  *USBD_CDC_GetFSCfgDesc (uint16_t *length);
+
+static uint8_t  *USBD_CDC_GetHSCfgDesc (uint16_t *length);
+
+static uint8_t  *USBD_CDC_GetOtherSpeedCfgDesc (uint16_t *length);
+
+static uint8_t  *USBD_CDC_GetOtherSpeedCfgDesc (uint16_t *length);
+
+uint8_t  *USBD_CDC_GetDeviceQualifierDescriptor (uint16_t *length);
+
+/* USB Standard Device Descriptor */
+__ALIGN_BEGIN static uint8_t USBD_CDC_DeviceQualifierDesc[USB_LEN_DEV_QUALIFIER_DESC] __ALIGN_END =
+{
+  USB_LEN_DEV_QUALIFIER_DESC,
+  USB_DESC_TYPE_DEVICE_QUALIFIER,
+  0x00,
+  0x02,
+  0x00,
+  0x00,
+  0x00,
+  0x40,
+  0x01,
+  0x00,
+};
+
+/**
+  * @}
+  */
+
+/** @defgroup USBD_CDC_Private_Variables
+  * @{
+  */
+
+
+/* CDC interface class callbacks structure */
+USBD_ClassTypeDef  USBD_CDC =
+{
+  USBD_CDC_Init,
+  USBD_CDC_DeInit,
+  USBD_CDC_Setup,
+  NULL,                 /* EP0_TxSent, */
+  USBD_CDC_EP0_RxReady,
+  USBD_CDC_DataIn,
+  USBD_CDC_DataOut,
+  NULL,
+  NULL,
+  NULL,
+
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  // USBD_CDC_GetHSCfgDesc,
+  // USBD_CDC_GetFSCfgDesc,
+  // USBD_CDC_GetOtherSpeedCfgDesc,
+  // USBD_CDC_GetDeviceQualifierDescriptor,
+};
+
+/* USB CDC device Configuration Descriptor */
+__ALIGN_BEGIN uint8_t USBD_CDC_CfgHSDesc[USB_CDC_CONFIG_DESC_SIZ] __ALIGN_END =
+{
+  /*Configuration Descriptor*/
+  0x09,   /* bLength: Configuration Descriptor size */
+  USB_DESC_TYPE_CONFIGURATION,      /* bDescriptorType: Configuration */
+  USB_CDC_CONFIG_DESC_SIZ,                /* wTotalLength:no of returned bytes */
+  0x00,
+  0x02,   /* bNumInterfaces: 2 interface */
+  0x01,   /* bConfigurationValue: Configuration value */
+  0x00,   /* iConfiguration: Index of string descriptor describing the configuration */
+  0xC0,   /* bmAttributes: self powered */
+  0x32,   /* MaxPower 0 mA */
+
+  /*---------------------------------------------------------------------------*/
+
+  /*Interface Descriptor */
+  0x09,   /* bLength: Interface Descriptor size */
+  USB_DESC_TYPE_INTERFACE,  /* bDescriptorType: Interface */
+  /* Interface descriptor type */
+  0x00,   /* bInterfaceNumber: Number of Interface */
+  0x00,   /* bAlternateSetting: Alternate setting */
+  0x01,   /* bNumEndpoints: One endpoints used */
+  0x02,   /* bInterfaceClass: Communication Interface Class */
+  0x02,   /* bInterfaceSubClass: Abstract Control Model */
+  0x01,   /* bInterfaceProtocol: Common AT commands */
+  0x00,   /* iInterface: */
+
+  /*Header Functional Descriptor*/
+  0x05,   /* bLength: Endpoint Descriptor size */
+  0x24,   /* bDescriptorType: CS_INTERFACE */
+  0x00,   /* bDescriptorSubtype: Header Func Desc */
+  0x10,   /* bcdCDC: spec release number */
+  0x01,
+
+  /*Call Management Functional Descriptor*/
+  0x05,   /* bFunctionLength */
+  0x24,   /* bDescriptorType: CS_INTERFACE */
+  0x01,   /* bDescriptorSubtype: Call Management Func Desc */
+  0x00,   /* bmCapabilities: D0+D1 */
+  0x01,   /* bDataInterface: 1 */
+
+  /*ACM Functional Descriptor*/
+  0x04,   /* bFunctionLength */
+  0x24,   /* bDescriptorType: CS_INTERFACE */
+  0x02,   /* bDescriptorSubtype: Abstract Control Management desc */
+  0x02,   /* bmCapabilities */
+
+  /*Union Functional Descriptor*/
+  0x05,   /* bFunctionLength */
+  0x24,   /* bDescriptorType: CS_INTERFACE */
+  0x06,   /* bDescriptorSubtype: Union func desc */
+  0x00,   /* bMasterInterface: Communication class interface */
+  0x01,   /* bSlaveInterface0: Data Class Interface */
+
+  /*Endpoint 2 Descriptor*/
+  0x07,                           /* bLength: Endpoint Descriptor size */
+  USB_DESC_TYPE_ENDPOINT,   /* bDescriptorType: Endpoint */
+  CDC_CMD_EP,                     /* bEndpointAddress */
+  0x03,                           /* bmAttributes: Interrupt */
+  LOBYTE(CDC_CMD_PACKET_SIZE),     /* wMaxPacketSize: */
+  HIBYTE(CDC_CMD_PACKET_SIZE),
+  CDC_HS_BINTERVAL,                           /* bInterval: */
+  /*---------------------------------------------------------------------------*/
+
+  /*Data class interface descriptor*/
+  0x09,   /* bLength: Endpoint Descriptor size */
+  USB_DESC_TYPE_INTERFACE,  /* bDescriptorType: */
+  0x01,   /* bInterfaceNumber: Number of Interface */
+  0x00,   /* bAlternateSetting: Alternate setting */
+  0x02,   /* bNumEndpoints: Two endpoints used */
+  0x0A,   /* bInterfaceClass: CDC */
+  0x00,   /* bInterfaceSubClass: */
+  0x00,   /* bInterfaceProtocol: */
+  0x00,   /* iInterface: */
+
+  /*Endpoint OUT Descriptor*/
+  0x07,   /* bLength: Endpoint Descriptor size */
+  USB_DESC_TYPE_ENDPOINT,      /* bDescriptorType: Endpoint */
+  CDC_OUT_EP,                        /* bEndpointAddress */
+  0x02,                              /* bmAttributes: Bulk */
+  LOBYTE(CDC_DATA_HS_MAX_PACKET_SIZE),  /* wMaxPacketSize: */
+  HIBYTE(CDC_DATA_HS_MAX_PACKET_SIZE),
+  0x00,                              /* bInterval: ignore for Bulk transfer */
+
+  /*Endpoint IN Descriptor*/
+  0x07,   /* bLength: Endpoint Descriptor size */
+  USB_DESC_TYPE_ENDPOINT,      /* bDescriptorType: Endpoint */
+  CDC_IN_EP,                         /* bEndpointAddress */
+  0x02,                              /* bmAttributes: Bulk */
+  LOBYTE(CDC_DATA_HS_MAX_PACKET_SIZE),  /* wMaxPacketSize: */
+  HIBYTE(CDC_DATA_HS_MAX_PACKET_SIZE),
+  0x00                               /* bInterval: ignore for Bulk transfer */
+} ;
+
+
+/* USB CDC device Configuration Descriptor */
+__ALIGN_BEGIN uint8_t USBD_CDC_CfgFSDesc[USB_CDC_CONFIG_DESC_SIZ] __ALIGN_END =
+{
+  /*Configuration Descriptor*/
+  0x09,   /* bLength: Configuration Descriptor size */
+  USB_DESC_TYPE_CONFIGURATION,      /* bDescriptorType: Configuration */
+  USB_CDC_CONFIG_DESC_SIZ,                /* wTotalLength:no of returned bytes */
+  0x00,
+  0x02,   /* bNumInterfaces: 2 interface */
+  0x01,   /* bConfigurationValue: Configuration value */
+  0x00,   /* iConfiguration: Index of string descriptor describing the configuration */
+  0xC0,   /* bmAttributes: self powered */
+  0x32,   /* MaxPower 0 mA */
+
+  /*---------------------------------------------------------------------------*/
+
+  /*Interface Descriptor */
+  0x09,   /* bLength: Interface Descriptor size */
+  USB_DESC_TYPE_INTERFACE,  /* bDescriptorType: Interface */
+  /* Interface descriptor type */
+  0x00,   /* bInterfaceNumber: Number of Interface */
+  0x00,   /* bAlternateSetting: Alternate setting */
+  0x01,   /* bNumEndpoints: One endpoints used */
+  0x02,   /* bInterfaceClass: Communication Interface Class */
+  0x02,   /* bInterfaceSubClass: Abstract Control Model */
+  0x01,   /* bInterfaceProtocol: Common AT commands */
+  0x00,   /* iInterface: */
+
+  /*Header Functional Descriptor*/
+  0x05,   /* bLength: Endpoint Descriptor size */
+  0x24,   /* bDescriptorType: CS_INTERFACE */
+  0x00,   /* bDescriptorSubtype: Header Func Desc */
+  0x10,   /* bcdCDC: spec release number */
+  0x01,
+
+  /*Call Management Functional Descriptor*/
+  0x05,   /* bFunctionLength */
+  0x24,   /* bDescriptorType: CS_INTERFACE */
+  0x01,   /* bDescriptorSubtype: Call Management Func Desc */
+  0x00,   /* bmCapabilities: D0+D1 */
+  0x01,   /* bDataInterface: 1 */
+
+  /*ACM Functional Descriptor*/
+  0x04,   /* bFunctionLength */
+  0x24,   /* bDescriptorType: CS_INTERFACE */
+  0x02,   /* bDescriptorSubtype: Abstract Control Management desc */
+  0x02,   /* bmCapabilities */
+
+  /*Union Functional Descriptor*/
+  0x05,   /* bFunctionLength */
+  0x24,   /* bDescriptorType: CS_INTERFACE */
+  0x06,   /* bDescriptorSubtype: Union func desc */
+  0x00,   /* bMasterInterface: Communication class interface */
+  0x01,   /* bSlaveInterface0: Data Class Interface */
+
+  /*Endpoint 2 Descriptor*/
+  0x07,                           /* bLength: Endpoint Descriptor size */
+  USB_DESC_TYPE_ENDPOINT,   /* bDescriptorType: Endpoint */
+  CDC_CMD_EP,                     /* bEndpointAddress */
+  0x03,                           /* bmAttributes: Interrupt */
+  LOBYTE(CDC_CMD_PACKET_SIZE),     /* wMaxPacketSize: */
+  HIBYTE(CDC_CMD_PACKET_SIZE),
+  CDC_FS_BINTERVAL,                           /* bInterval: */
+  /*---------------------------------------------------------------------------*/
+
+  /*Data class interface descriptor*/
+  0x09,   /* bLength: Endpoint Descriptor size */
+  USB_DESC_TYPE_INTERFACE,  /* bDescriptorType: */
+  0x01,   /* bInterfaceNumber: Number of Interface */
+  0x00,   /* bAlternateSetting: Alternate setting */
+  0x02,   /* bNumEndpoints: Two endpoints used */
+  0x0A,   /* bInterfaceClass: CDC */
+  0x00,   /* bInterfaceSubClass: */
+  0x00,   /* bInterfaceProtocol: */
+  0x00,   /* iInterface: */
+
+  /*Endpoint OUT Descriptor*/
+  0x07,   /* bLength: Endpoint Descriptor size */
+  USB_DESC_TYPE_ENDPOINT,      /* bDescriptorType: Endpoint */
+  CDC_OUT_EP,                        /* bEndpointAddress */
+  0x02,                              /* bmAttributes: Bulk */
+  LOBYTE(CDC_DATA_FS_MAX_PACKET_SIZE),  /* wMaxPacketSize: */
+  HIBYTE(CDC_DATA_FS_MAX_PACKET_SIZE),
+  0x00,                              /* bInterval: ignore for Bulk transfer */
+
+  /*Endpoint IN Descriptor*/
+  0x07,   /* bLength: Endpoint Descriptor size */
+  USB_DESC_TYPE_ENDPOINT,      /* bDescriptorType: Endpoint */
+  CDC_IN_EP,                         /* bEndpointAddress */
+  0x02,                              /* bmAttributes: Bulk */
+  LOBYTE(CDC_DATA_FS_MAX_PACKET_SIZE),  /* wMaxPacketSize: */
+  HIBYTE(CDC_DATA_FS_MAX_PACKET_SIZE),
+  0x00                               /* bInterval: ignore for Bulk transfer */
+} ;
+
+__ALIGN_BEGIN uint8_t USBD_CDC_OtherSpeedCfgDesc[USB_CDC_CONFIG_DESC_SIZ] __ALIGN_END =
+{
+  0x09,   /* bLength: Configuation Descriptor size */
+  USB_DESC_TYPE_OTHER_SPEED_CONFIGURATION,
+  USB_CDC_CONFIG_DESC_SIZ,
+  0x00,
+  0x02,   /* bNumInterfaces: 2 interfaces */
+  0x01,   /* bConfigurationValue: */
+  0x04,   /* iConfiguration: */
+  0xC0,   /* bmAttributes: */
+  0x32,   /* MaxPower 100 mA */
+
+  /*Interface Descriptor */
+  0x09,   /* bLength: Interface Descriptor size */
+  USB_DESC_TYPE_INTERFACE,  /* bDescriptorType: Interface */
+  /* Interface descriptor type */
+  0x00,   /* bInterfaceNumber: Number of Interface */
+  0x00,   /* bAlternateSetting: Alternate setting */
+  0x01,   /* bNumEndpoints: One endpoints used */
+  0x02,   /* bInterfaceClass: Communication Interface Class */
+  0x02,   /* bInterfaceSubClass: Abstract Control Model */
+  0x01,   /* bInterfaceProtocol: Common AT commands */
+  0x00,   /* iInterface: */
+
+  /*Header Functional Descriptor*/
+  0x05,   /* bLength: Endpoint Descriptor size */
+  0x24,   /* bDescriptorType: CS_INTERFACE */
+  0x00,   /* bDescriptorSubtype: Header Func Desc */
+  0x10,   /* bcdCDC: spec release number */
+  0x01,
+
+  /*Call Management Functional Descriptor*/
+  0x05,   /* bFunctionLength */
+  0x24,   /* bDescriptorType: CS_INTERFACE */
+  0x01,   /* bDescriptorSubtype: Call Management Func Desc */
+  0x00,   /* bmCapabilities: D0+D1 */
+  0x01,   /* bDataInterface: 1 */
+
+  /*ACM Functional Descriptor*/
+  0x04,   /* bFunctionLength */
+  0x24,   /* bDescriptorType: CS_INTERFACE */
+  0x02,   /* bDescriptorSubtype: Abstract Control Management desc */
+  0x02,   /* bmCapabilities */
+
+  /*Union Functional Descriptor*/
+  0x05,   /* bFunctionLength */
+  0x24,   /* bDescriptorType: CS_INTERFACE */
+  0x06,   /* bDescriptorSubtype: Union func desc */
+  0x00,   /* bMasterInterface: Communication class interface */
+  0x01,   /* bSlaveInterface0: Data Class Interface */
+
+  /*Endpoint 2 Descriptor*/
+  0x07,                           /* bLength: Endpoint Descriptor size */
+  USB_DESC_TYPE_ENDPOINT      ,   /* bDescriptorType: Endpoint */
+  CDC_CMD_EP,                     /* bEndpointAddress */
+  0x03,                           /* bmAttributes: Interrupt */
+  LOBYTE(CDC_CMD_PACKET_SIZE),     /* wMaxPacketSize: */
+  HIBYTE(CDC_CMD_PACKET_SIZE),
+  CDC_FS_BINTERVAL,                           /* bInterval: */
+
+  /*---------------------------------------------------------------------------*/
+
+  /*Data class interface descriptor*/
+  0x09,   /* bLength: Endpoint Descriptor size */
+  USB_DESC_TYPE_INTERFACE,  /* bDescriptorType: */
+  0x01,   /* bInterfaceNumber: Number of Interface */
+  0x00,   /* bAlternateSetting: Alternate setting */
+  0x02,   /* bNumEndpoints: Two endpoints used */
+  0x0A,   /* bInterfaceClass: CDC */
+  0x00,   /* bInterfaceSubClass: */
+  0x00,   /* bInterfaceProtocol: */
+  0x00,   /* iInterface: */
+
+  /*Endpoint OUT Descriptor*/
+  0x07,   /* bLength: Endpoint Descriptor size */
+  USB_DESC_TYPE_ENDPOINT,      /* bDescriptorType: Endpoint */
+  CDC_OUT_EP,                        /* bEndpointAddress */
+  0x02,                              /* bmAttributes: Bulk */
+  0x40,                              /* wMaxPacketSize: */
+  0x00,
+  0x00,                              /* bInterval: ignore for Bulk transfer */
+
+  /*Endpoint IN Descriptor*/
+  0x07,   /* bLength: Endpoint Descriptor size */
+  USB_DESC_TYPE_ENDPOINT,     /* bDescriptorType: Endpoint */
+  CDC_IN_EP,                        /* bEndpointAddress */
+  0x02,                             /* bmAttributes: Bulk */
+  0x40,                             /* wMaxPacketSize: */
+  0x00,
+  0x00                              /* bInterval */
+};
+
+/**
+  * @}
+  */
+
+/** @defgroup USBD_CDC_Private_Functions
+  * @{
+  */
+
+/**
+  * @brief  USBD_CDC_Init
+  *         Initialize the CDC interface
+  * @param  pdev: device instance
+  * @param  cfgidx: Configuration index
+  * @retval status
+  */
+static uint8_t  USBD_CDC_Init (USBD_HandleTypeDef *pdev, uint8_t cfgidx)
+{
+  uint8_t ret = 0U;
+  USBD_CDC_HandleTypeDef   *hcdc;
+
+  if(pdev->dev_speed == USBD_SPEED_HIGH)
+  {
+    /* Open EP IN */
+    USBD_LL_OpenEP(pdev, CDC_IN_EP, USBD_EP_TYPE_BULK,
+                   CDC_DATA_HS_IN_PACKET_SIZE);
+
+    pdev->ep_in[CDC_IN_EP & 0xFU].is_used = 1U;
+
+    /* Open EP OUT */
+    USBD_LL_OpenEP(pdev, CDC_OUT_EP, USBD_EP_TYPE_BULK,
+                   CDC_DATA_HS_OUT_PACKET_SIZE);
+
+    pdev->ep_out[CDC_OUT_EP & 0xFU].is_used = 1U;
+
+  }
+  else
+  {
+    /* Open EP IN */
+    USBD_LL_OpenEP(pdev, CDC_IN_EP, USBD_EP_TYPE_BULK,
+                   CDC_DATA_FS_IN_PACKET_SIZE);
+
+    pdev->ep_in[CDC_IN_EP & 0xFU].is_used = 1U;
+
+    /* Open EP OUT */
+    USBD_LL_OpenEP(pdev, CDC_OUT_EP, USBD_EP_TYPE_BULK,
+                   CDC_DATA_FS_OUT_PACKET_SIZE);
+
+    pdev->ep_out[CDC_OUT_EP & 0xFU].is_used = 1U;
+  }
+  /* Open Command IN EP */
+  USBD_LL_OpenEP(pdev, CDC_CMD_EP, USBD_EP_TYPE_INTR, CDC_CMD_PACKET_SIZE);
+  pdev->ep_in[CDC_CMD_EP & 0xFU].is_used = 1U;
+
+  static USBD_CDC_HandleTypeDef mem;
+  pdev->pClassData = &mem;
+
+  if(pdev->pClassData == NULL)
+  {
+    ret = 1U;
+  }
+  else
+  {
+    hcdc = (USBD_CDC_HandleTypeDef*) pdev->pClassData;
+
+    /* Init  physical Interface components */
+    ((USBD_CDC_ItfTypeDef *)pdev->pUserData)->Init();
+
+    /* Init Xfer states */
+    hcdc->TxState = 0U;
+    hcdc->RxState = 0U;
+
+    if(pdev->dev_speed == USBD_SPEED_HIGH)
+    {
+      /* Prepare Out endpoint to receive next packet */
+      USBD_LL_PrepareReceive(pdev, CDC_OUT_EP, hcdc->RxBuffer,
+                             CDC_DATA_HS_OUT_PACKET_SIZE);
+    }
+    else
+    {
+      /* Prepare Out endpoint to receive next packet */
+      USBD_LL_PrepareReceive(pdev, CDC_OUT_EP, hcdc->RxBuffer,
+                             CDC_DATA_FS_OUT_PACKET_SIZE);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  USBD_CDC_Init
+  *         DeInitialize the CDC layer
+  * @param  pdev: device instance
+  * @param  cfgidx: Configuration index
+  * @retval status
+  */
+static uint8_t  USBD_CDC_DeInit (USBD_HandleTypeDef *pdev, uint8_t cfgidx)
+{
+  uint8_t ret = 0U;
+
+  /* Close EP IN */
+  USBD_LL_CloseEP(pdev, CDC_IN_EP);
+  pdev->ep_in[CDC_IN_EP & 0xFU].is_used = 0U;
+
+  /* Close EP OUT */
+  USBD_LL_CloseEP(pdev, CDC_OUT_EP);
+  pdev->ep_out[CDC_OUT_EP & 0xFU].is_used = 0U;
+
+  /* Close Command IN EP */
+  USBD_LL_CloseEP(pdev, CDC_CMD_EP);
+  pdev->ep_in[CDC_CMD_EP & 0xFU].is_used = 0U;
+
+  /* DeInit  physical Interface components */
+  if(pdev->pClassData != NULL)
+  {
+    ((USBD_CDC_ItfTypeDef *)pdev->pUserData)->DeInit();
+    pdev->pClassData = NULL;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  USBD_CDC_Setup
+  *         Handle the CDC specific requests
+  * @param  pdev: instance
+  * @param  req: usb requests
+  * @retval status
+  */
+static uint8_t  USBD_CDC_Setup (USBD_HandleTypeDef *pdev,
+                                USBD_SetupReqTypedef *req)
+{
+  USBD_CDC_HandleTypeDef   *hcdc = (USBD_CDC_HandleTypeDef*) pdev->pClassData;
+  uint8_t ifalt = 0U;
+  uint16_t status_info = 0U;
+  uint8_t ret = USBD_OK;
+
+  switch (req->bmRequest & USB_REQ_TYPE_MASK)
+  {
+  case USB_REQ_TYPE_CLASS :
+    if (req->wLength)
+    {
+      if (req->bmRequest & 0x80U)
+      {
+        ((USBD_CDC_ItfTypeDef *)pdev->pUserData)->Control(req->bRequest,
+                                                          (uint8_t *)(void *)hcdc->data,
+                                                          req->wLength);
+
+          USBD_CtlSendData (pdev, (uint8_t *)(void *)hcdc->data, req->wLength);
+      }
+      else
+      {
+        hcdc->CmdOpCode = req->bRequest;
+        hcdc->CmdLength = (uint8_t)req->wLength;
+
+        USBD_CtlPrepareRx (pdev, (uint8_t *)(void *)hcdc->data, req->wLength);
+      }
+    }
+    else
+    {
+      ((USBD_CDC_ItfTypeDef *)pdev->pUserData)->Control(req->bRequest,
+                                                        (uint8_t *)(void *)req, 0U);
+    }
+    break;
+
+  case USB_REQ_TYPE_STANDARD:
+    switch (req->bRequest)
+    {
+    case USB_REQ_GET_STATUS:
+      if (pdev->dev_state == USBD_STATE_CONFIGURED)
+      {
+        USBD_CtlSendData (pdev, (uint8_t *)(void *)&status_info, 2U);
+      }
+      else
+      {
+        USBD_CtlError (pdev, req);
+			  ret = USBD_FAIL;
+      }
+      break;
+
+    case USB_REQ_GET_INTERFACE:
+      if (pdev->dev_state == USBD_STATE_CONFIGURED)
+      {
+        USBD_CtlSendData (pdev, &ifalt, 1U);
+      }
+      else
+      {
+        USBD_CtlError (pdev, req);
+			  ret = USBD_FAIL;
+      }
+      break;
+
+    case USB_REQ_SET_INTERFACE:
+      if (pdev->dev_state != USBD_STATE_CONFIGURED)
+      {
+        USBD_CtlError (pdev, req);
+			  ret = USBD_FAIL;
+      }
+      break;
+    case USB_REQ_GET_DESCRIPTOR:
+    break;
+    default:
+      USBD_CtlError (pdev, req);
+      ret = USBD_FAIL;
+      break;
+    }
+    break;
+
+  default:
+    USBD_CtlError (pdev, req);
+    ret = USBD_FAIL;
+    break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  USBD_CDC_DataIn
+  *         Data sent on non-control IN endpoint
+  * @param  pdev: device instance
+  * @param  epnum: endpoint number
+  * @retval status
+  */
+static uint8_t  USBD_CDC_DataIn (USBD_HandleTypeDef *pdev, uint8_t epnum)
+{
+  USBD_CDC_HandleTypeDef *hcdc = (USBD_CDC_HandleTypeDef*)pdev->pClassData;
+  PCD_HandleTypeDef *hpcd = pdev->pData;
+
+  if(pdev->pClassData != NULL)
+  {
+    if((pdev->ep_in[epnum].total_length > 0U) && ((pdev->ep_in[epnum].total_length % hpcd->IN_ep[epnum].maxpacket) == 0U))
+    {
+      /* Update the packet total length */
+      pdev->ep_in[epnum].total_length = 0U;
+
+      /* Send ZLP */
+      USBD_LL_Transmit (pdev, epnum, NULL, 0U);
+    }
+    else
+    {
+      hcdc->TxState = 0U;
+    }
+    return USBD_OK;
+  }
+  else
+  {
+    return USBD_FAIL;
+  }
+}
+
+/**
+  * @brief  USBD_CDC_DataOut
+  *         Data received on non-control Out endpoint
+  * @param  pdev: device instance
+  * @param  epnum: endpoint number
+  * @retval status
+  */
+static uint8_t  USBD_CDC_DataOut (USBD_HandleTypeDef *pdev, uint8_t epnum)
+{
+  USBD_CDC_HandleTypeDef   *hcdc = (USBD_CDC_HandleTypeDef*) pdev->pClassData;
+
+  /* Get the received data length */
+  hcdc->RxLength = USBD_LL_GetRxDataSize (pdev, epnum);
+
+  /* USB data will be immediately processed, this allow next USB traffic being
+  NAKed till the end of the application Xfer */
+  if(pdev->pClassData != NULL)
+  {
+    ((USBD_CDC_ItfTypeDef *)pdev->pUserData)->Receive(hcdc->RxBuffer, &hcdc->RxLength);
+
+    return USBD_OK;
+  }
+  else
+  {
+    return USBD_FAIL;
+  }
+}
+
+/**
+  * @brief  USBD_CDC_EP0_RxReady
+  *         Handle EP0 Rx Ready event
+  * @param  pdev: device instance
+  * @retval status
+  */
+static uint8_t  USBD_CDC_EP0_RxReady (USBD_HandleTypeDef *pdev)
+{
+  USBD_CDC_HandleTypeDef   *hcdc = (USBD_CDC_HandleTypeDef*) pdev->pClassData;
+
+  if((pdev->pUserData != NULL) && (hcdc->CmdOpCode != 0xFFU))
+  {
+    ((USBD_CDC_ItfTypeDef *)pdev->pUserData)->Control(hcdc->CmdOpCode,
+                                                      (uint8_t *)(void *)hcdc->data,
+                                                      (uint16_t)hcdc->CmdLength);
+      hcdc->CmdOpCode = 0xFFU;
+
+  }
+  return USBD_OK;
+}
+
+/**
+  * @brief  USBD_CDC_GetFSCfgDesc
+  *         Return configuration descriptor
+  * @param  speed : current device speed
+  * @param  length : pointer data length
+  * @retval pointer to descriptor buffer
+  */
+static uint8_t  *USBD_CDC_GetFSCfgDesc (uint16_t *length)
+{
+  *length = sizeof (USBD_CDC_CfgFSDesc);
+  return USBD_CDC_CfgFSDesc;
+}
+
+/**
+  * @brief  USBD_CDC_GetHSCfgDesc
+  *         Return configuration descriptor
+  * @param  speed : current device speed
+  * @param  length : pointer data length
+  * @retval pointer to descriptor buffer
+  */
+static uint8_t  *USBD_CDC_GetHSCfgDesc (uint16_t *length)
+{
+  *length = sizeof (USBD_CDC_CfgHSDesc);
+  return USBD_CDC_CfgHSDesc;
+}
+
+/**
+  * @brief  USBD_CDC_GetCfgDesc
+  *         Return configuration descriptor
+  * @param  speed : current device speed
+  * @param  length : pointer data length
+  * @retval pointer to descriptor buffer
+  */
+static uint8_t  *USBD_CDC_GetOtherSpeedCfgDesc (uint16_t *length)
+{
+  *length = sizeof (USBD_CDC_OtherSpeedCfgDesc);
+  return USBD_CDC_OtherSpeedCfgDesc;
+}
+
+/**
+* @brief  DeviceQualifierDescriptor
+*         return Device Qualifier descriptor
+* @param  length : pointer data length
+* @retval pointer to descriptor buffer
+*/
+uint8_t  *USBD_CDC_GetDeviceQualifierDescriptor (uint16_t *length)
+{
+  *length = sizeof (USBD_CDC_DeviceQualifierDesc);
+  return USBD_CDC_DeviceQualifierDesc;
+}
+
+/**
+* @brief  USBD_CDC_RegisterInterface
+  * @param  pdev: device instance
+  * @param  fops: CD  Interface callback
+  * @retval status
+  */
+uint8_t  USBD_CDC_RegisterInterface  (USBD_HandleTypeDef   *pdev,
+                                      USBD_CDC_ItfTypeDef *fops)
+{
+  uint8_t  ret = USBD_FAIL;
+
+  if(fops != NULL)
+  {
+    pdev->pUserData= fops;
+    ret = USBD_OK;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  USBD_CDC_SetTxBuffer
+  * @param  pdev: device instance
+  * @param  pbuff: Tx Buffer
+  * @retval status
+  */
+uint8_t  USBD_CDC_SetTxBuffer  (USBD_HandleTypeDef   *pdev,
+                                uint8_t  *pbuff,
+                                uint16_t length)
+{
+  USBD_CDC_HandleTypeDef   *hcdc = (USBD_CDC_HandleTypeDef*) pdev->pClassData;
+
+  hcdc->TxBuffer = pbuff;
+  hcdc->TxLength = length;
+
+  return USBD_OK;
+}
+
+
+/**
+  * @brief  USBD_CDC_SetRxBuffer
+  * @param  pdev: device instance
+  * @param  pbuff: Rx Buffer
+  * @retval status
+  */
+uint8_t  USBD_CDC_SetRxBuffer  (USBD_HandleTypeDef   *pdev,
+                                   uint8_t  *pbuff)
+{
+  USBD_CDC_HandleTypeDef   *hcdc = (USBD_CDC_HandleTypeDef*) pdev->pClassData;
+
+  hcdc->RxBuffer = pbuff;
+
+  return USBD_OK;
+}
+
+/**
+  * @brief  USBD_CDC_TransmitPacket
+  *         Transmit packet on IN endpoint
+  * @param  pdev: device instance
+  * @retval status
+  */
+uint8_t  USBD_CDC_TransmitPacket(USBD_HandleTypeDef *pdev)
+{
+  USBD_CDC_HandleTypeDef   *hcdc = (USBD_CDC_HandleTypeDef*) pdev->pClassData;
+
+  if(pdev->pClassData != NULL)
+  {
+    if(hcdc->TxState == 0U)
+    {
+      /* Tx Transfer in progress */
+      hcdc->TxState = 1U;
+
+      /* Update the packet total length */
+      pdev->ep_in[CDC_IN_EP & 0xFU].total_length = hcdc->TxLength;
+
+      /* Transmit next packet */
+      USBD_LL_Transmit(pdev, CDC_IN_EP, hcdc->TxBuffer,
+                       (uint16_t)hcdc->TxLength);
+
+      return USBD_OK;
+    }
+    else
+    {
+      return USBD_BUSY;
+    }
+  }
+  else
+  {
+    return USBD_FAIL;
+  }
+}
+
+
+/**
+  * @brief  USBD_CDC_ReceivePacket
+  *         prepare OUT Endpoint for reception
+  * @param  pdev: device instance
+  * @retval status
+  */
+uint8_t  USBD_CDC_ReceivePacket(USBD_HandleTypeDef *pdev)
+{
+  USBD_CDC_HandleTypeDef   *hcdc = (USBD_CDC_HandleTypeDef*) pdev->pClassData;
+
+  /* Suspend or Resume USB Out process */
+  if(pdev->pClassData != NULL)
+  {
+    if(pdev->dev_speed == USBD_SPEED_HIGH  )
+    {
+      /* Prepare Out endpoint to receive next packet */
+      USBD_LL_PrepareReceive(pdev,
+                             CDC_OUT_EP,
+                             hcdc->RxBuffer,
+                             CDC_DATA_HS_OUT_PACKET_SIZE);
+    }
+    else
+    {
+      /* Prepare Out endpoint to receive next packet */
+      USBD_LL_PrepareReceive(pdev,
+                             CDC_OUT_EP,
+                             hcdc->RxBuffer,
+                             CDC_DATA_FS_OUT_PACKET_SIZE);
+    }
+    return USBD_OK;
+  }
+  else
+  {
+    return USBD_FAIL;
+  }
+}
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/targets/stm32l442/lib/usbd/usbd_cdc.h
+++ b/targets/stm32l442/lib/usbd/usbd_cdc.h
@@ -1,0 +1,205 @@
+/**
+  ******************************************************************************
+  * @file    usbd_cdc.h
+  * @author  MCD Application Team
+  * @brief   header file for the usbd_cdc.c file.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2017 STMicroelectronics International N.V.
+  * All rights reserved.</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without
+  * modification, are permitted, provided that the following conditions are met:
+  *
+  * 1. Redistribution of source code must retain the above copyright notice,
+  *    this list of conditions and the following disclaimer.
+  * 2. Redistributions in binary form must reproduce the above copyright notice,
+  *    this list of conditions and the following disclaimer in the documentation
+  *    and/or other materials provided with the distribution.
+  * 3. Neither the name of STMicroelectronics nor the names of other
+  *    contributors to this software may be used to endorse or promote products
+  *    derived from this software without specific written permission.
+  * 4. This software, including modifications and/or derivative works of this
+  *    software, must execute solely and exclusively on microcontroller or
+  *    microprocessor devices manufactured by or for STMicroelectronics.
+  * 5. Redistribution and use of this software other than as permitted under
+  *    this license is void and will automatically terminate your rights under
+  *    this license.
+  *
+  * THIS SOFTWARE IS PROVIDED BY STMICROELECTRONICS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS, IMPLIED OR STATUTORY WARRANTIES, INCLUDING, BUT NOT
+  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  * PARTICULAR PURPOSE AND NON-INFRINGEMENT OF THIRD PARTY INTELLECTUAL PROPERTY
+  * RIGHTS ARE DISCLAIMED TO THE FULLEST EXTENT PERMITTED BY LAW. IN NO EVENT
+  * SHALL STMICROELECTRONICS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+  * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+  * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+  * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __USB_CDC_H
+#define __USB_CDC_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include  "usbd_ioreq.h"
+
+/** @addtogroup STM32_USB_DEVICE_LIBRARY
+  * @{
+  */
+
+/** @defgroup usbd_cdc
+  * @brief This file is the Header file for usbd_cdc.c
+  * @{
+  */
+
+
+/** @defgroup usbd_cdc_Exported_Defines
+  * @{
+  */
+#define CDC_IN_EP                                   0x82U  /* EP1 for data IN */
+#define CDC_OUT_EP                                  0x02U  /* EP1 for data OUT */
+#define CDC_CMD_EP                                  0x83U  /* EP2 for CDC commands */
+
+#ifndef CDC_HS_BINTERVAL
+  #define CDC_HS_BINTERVAL                          0x10U
+#endif /* CDC_HS_BINTERVAL */
+
+#ifndef CDC_FS_BINTERVAL
+  #define CDC_FS_BINTERVAL                          0x10U
+#endif /* CDC_FS_BINTERVAL */
+
+/* CDC Endpoints parameters: you can fine tune these values depending on the needed baudrates and performance. */
+#define CDC_DATA_HS_MAX_PACKET_SIZE                 64U  /* Endpoint IN & OUT Packet size */
+#define CDC_DATA_FS_MAX_PACKET_SIZE                 64U  /* Endpoint IN & OUT Packet size */
+#define CDC_CMD_PACKET_SIZE                         8U  /* Control Endpoint Packet size */
+
+#define USB_CDC_CONFIG_DESC_SIZ                     67U
+#define CDC_DATA_HS_IN_PACKET_SIZE                  CDC_DATA_HS_MAX_PACKET_SIZE
+#define CDC_DATA_HS_OUT_PACKET_SIZE                 CDC_DATA_HS_MAX_PACKET_SIZE
+
+#define CDC_DATA_FS_IN_PACKET_SIZE                  CDC_DATA_FS_MAX_PACKET_SIZE
+#define CDC_DATA_FS_OUT_PACKET_SIZE                 CDC_DATA_FS_MAX_PACKET_SIZE
+
+/*---------------------------------------------------------------------*/
+/*  CDC definitions                                                    */
+/*---------------------------------------------------------------------*/
+#define CDC_SEND_ENCAPSULATED_COMMAND               0x00U
+#define CDC_GET_ENCAPSULATED_RESPONSE               0x01U
+#define CDC_SET_COMM_FEATURE                        0x02U
+#define CDC_GET_COMM_FEATURE                        0x03U
+#define CDC_CLEAR_COMM_FEATURE                      0x04U
+#define CDC_SET_LINE_CODING                         0x20U
+#define CDC_GET_LINE_CODING                         0x21U
+#define CDC_SET_CONTROL_LINE_STATE                  0x22U
+#define CDC_SEND_BREAK                              0x23U
+
+/**
+  * @}
+  */
+
+
+/** @defgroup USBD_CORE_Exported_TypesDefinitions
+  * @{
+  */
+
+/**
+  * @}
+  */
+typedef struct
+{
+  uint32_t bitrate;
+  uint8_t  format;
+  uint8_t  paritytype;
+  uint8_t  datatype;
+}USBD_CDC_LineCodingTypeDef;
+
+typedef struct _USBD_CDC_Itf
+{
+  int8_t (* Init)          (void);
+  int8_t (* DeInit)        (void);
+  int8_t (* Control)       (uint8_t cmd, uint8_t* pbuf, uint16_t length);
+  int8_t (* Receive)       (uint8_t* Buf, uint32_t *Len);
+
+}USBD_CDC_ItfTypeDef;
+
+
+typedef struct
+{
+  uint32_t data[CDC_DATA_HS_MAX_PACKET_SIZE / 4U];      /* Force 32bits alignment */
+  uint8_t  CmdOpCode;
+  uint8_t  CmdLength;
+  uint8_t  *RxBuffer;
+  uint8_t  *TxBuffer;
+  uint32_t RxLength;
+  uint32_t TxLength;
+
+  __IO uint32_t TxState;
+  __IO uint32_t RxState;
+}
+USBD_CDC_HandleTypeDef;
+
+
+
+/** @defgroup USBD_CORE_Exported_Macros
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/** @defgroup USBD_CORE_Exported_Variables
+  * @{
+  */
+
+extern USBD_ClassTypeDef  USBD_CDC;
+#define USBD_CDC_CLASS    &USBD_CDC
+/**
+  * @}
+  */
+
+/** @defgroup USB_CORE_Exported_Functions
+  * @{
+  */
+uint8_t  USBD_CDC_RegisterInterface  (USBD_HandleTypeDef   *pdev,
+                                      USBD_CDC_ItfTypeDef *fops);
+
+uint8_t  USBD_CDC_SetTxBuffer        (USBD_HandleTypeDef   *pdev,
+                                      uint8_t  *pbuff,
+                                      uint16_t length);
+
+uint8_t  USBD_CDC_SetRxBuffer        (USBD_HandleTypeDef   *pdev,
+                                      uint8_t  *pbuff);
+
+uint8_t  USBD_CDC_ReceivePacket      (USBD_HandleTypeDef *pdev);
+
+uint8_t  USBD_CDC_TransmitPacket     (USBD_HandleTypeDef *pdev);
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* __USB_CDC_H */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/targets/stm32l442/lib/usbd/usbd_cdc_if.c
+++ b/targets/stm32l442/lib/usbd/usbd_cdc_if.c
@@ -1,0 +1,336 @@
+/**
+  ******************************************************************************
+  * @file           : usbd_cdc_if.c
+  * @version        : v2.0_Cube
+  * @brief          : Usb device for Virtual Com Port.
+  ******************************************************************************
+  * This notice applies to any and all portions of this file
+  * that are not between comment pairs USER CODE BEGIN and
+  * USER CODE END. Other portions of this file, whether
+  * inserted by the user or by software development tools
+  * are owned by their respective copyright owners.
+  *
+  * Copyright (c) 2018 STMicroelectronics International N.V.
+  * All rights reserved.
+  *
+  * Redistribution and use in source and binary forms, with or without
+  * modification, are permitted, provided that the following conditions are met:
+  *
+  * 1. Redistribution of source code must retain the above copyright notice,
+  *    this list of conditions and the following disclaimer.
+  * 2. Redistributions in binary form must reproduce the above copyright notice,
+  *    this list of conditions and the following disclaimer in the documentation
+  *    and/or other materials provided with the distribution.
+  * 3. Neither the name of STMicroelectronics nor the names of other
+  *    contributors to this software may be used to endorse or promote products
+  *    derived from this software without specific written permission.
+  * 4. This software, including modifications and/or derivative works of this
+  *    software, must execute solely and exclusively on microcontroller or
+  *    microprocessor devices manufactured by or for STMicroelectronics.
+  * 5. Redistribution and use of this software other than as permitted under
+  *    this license is void and will automatically terminate your rights under
+  *    this license.
+  *
+  * THIS SOFTWARE IS PROVIDED BY STMICROELECTRONICS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS, IMPLIED OR STATUTORY WARRANTIES, INCLUDING, BUT NOT
+  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  * PARTICULAR PURPOSE AND NON-INFRINGEMENT OF THIRD PARTY INTELLECTUAL PROPERTY
+  * RIGHTS ARE DISCLAIMED TO THE FULLEST EXTENT PERMITTED BY LAW. IN NO EVENT
+  * SHALL STMICROELECTRONICS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+  * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+  * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+  * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "usbd_cdc_if.h"
+
+/* USER CODE BEGIN INCLUDE */
+
+/* USER CODE END INCLUDE */
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+
+/* USER CODE BEGIN PV */
+/* Private variables ---------------------------------------------------------*/
+
+/* USER CODE END PV */
+
+/** @addtogroup STM32_USB_OTG_DEVICE_LIBRARY
+  * @brief Usb device library.
+  * @{
+  */
+
+/** @addtogroup USBD_CDC_IF
+  * @{
+  */
+
+/** @defgroup USBD_CDC_IF_Private_TypesDefinitions USBD_CDC_IF_Private_TypesDefinitions
+  * @brief Private types.
+  * @{
+  */
+
+/* USER CODE BEGIN PRIVATE_TYPES */
+
+/* USER CODE END PRIVATE_TYPES */
+
+/**
+  * @}
+  */
+
+/** @defgroup USBD_CDC_IF_Private_Defines USBD_CDC_IF_Private_Defines
+  * @brief Private defines.
+  * @{
+  */
+
+/* USER CODE BEGIN PRIVATE_DEFINES */
+/* Define size for the receive and transmit buffer over CDC */
+/* It's up to user to redefine and/or remove those define */
+#define APP_RX_DATA_SIZE  1000
+#define APP_TX_DATA_SIZE  1000
+/* USER CODE END PRIVATE_DEFINES */
+
+/**
+  * @}
+  */
+
+/** @defgroup USBD_CDC_IF_Private_Macros USBD_CDC_IF_Private_Macros
+  * @brief Private macros.
+  * @{
+  */
+
+/* USER CODE BEGIN PRIVATE_MACRO */
+
+/* USER CODE END PRIVATE_MACRO */
+
+/**
+  * @}
+  */
+
+/** @defgroup USBD_CDC_IF_Private_Variables USBD_CDC_IF_Private_Variables
+  * @brief Private variables.
+  * @{
+  */
+/* Create buffer for reception and transmission           */
+/* It's up to user to redefine and/or remove those define */
+/** Received data over USB are stored in this buffer      */
+uint8_t UserRxBufferFS[APP_RX_DATA_SIZE];
+
+/** Data to send over USB CDC are stored in this buffer   */
+uint8_t UserTxBufferFS[APP_TX_DATA_SIZE];
+
+/* USER CODE BEGIN PRIVATE_VARIABLES */
+
+/* USER CODE END PRIVATE_VARIABLES */
+
+/**
+  * @}
+  */
+
+/** @defgroup USBD_CDC_IF_Exported_Variables USBD_CDC_IF_Exported_Variables
+  * @brief Public variables.
+  * @{
+  */
+
+
+/* USER CODE BEGIN EXPORTED_VARIABLES */
+
+/* USER CODE END EXPORTED_VARIABLES */
+
+/**
+  * @}
+  */
+
+/** @defgroup USBD_CDC_IF_Private_FunctionPrototypes USBD_CDC_IF_Private_FunctionPrototypes
+  * @brief Private functions declaration.
+  * @{
+  */
+
+static int8_t CDC_Init_FS(void);
+static int8_t CDC_DeInit_FS(void);
+static int8_t CDC_Control_FS(uint8_t cmd, uint8_t* pbuf, uint16_t length);
+static int8_t CDC_Receive_FS(uint8_t* pbuf, uint32_t *Len);
+
+/* USER CODE BEGIN PRIVATE_FUNCTIONS_DECLARATION */
+
+/* USER CODE END PRIVATE_FUNCTIONS_DECLARATION */
+
+/**
+  * @}
+  */
+
+USBD_CDC_ItfTypeDef USBD_Interface_fops_FS =
+{
+  CDC_Init_FS,
+  CDC_DeInit_FS,
+  CDC_Control_FS,
+  CDC_Receive_FS
+};
+
+/* Private functions ---------------------------------------------------------*/
+/**
+  * @brief  Initializes the CDC media low layer over the FS USB IP
+  * @retval USBD_OK if all operations are OK else USBD_FAIL
+  */
+static int8_t CDC_Init_FS(void)
+{
+  /* USER CODE BEGIN 3 */
+  /* Set Application Buffers */
+  USBD_CDC_SetTxBuffer(&Solo_USBD_Device, UserTxBufferFS, 0);
+  USBD_CDC_SetRxBuffer(&Solo_USBD_Device, UserRxBufferFS);
+  return (USBD_OK);
+  /* USER CODE END 3 */
+}
+
+/**
+  * @brief  DeInitializes the CDC media low layer
+  * @retval USBD_OK if all operations are OK else USBD_FAIL
+  */
+static int8_t CDC_DeInit_FS(void)
+{
+  /* USER CODE BEGIN 4 */
+  return (USBD_OK);
+  /* USER CODE END 4 */
+}
+
+/**
+  * @brief  Manage the CDC class requests
+  * @param  cmd: Command code
+  * @param  pbuf: Buffer containing command data (request parameters)
+  * @param  length: Number of data to be sent (in bytes)
+  * @retval Result of the operation: USBD_OK if all operations are OK else USBD_FAIL
+  */
+static int8_t CDC_Control_FS(uint8_t cmd, uint8_t* pbuf, uint16_t length)
+{
+  /* USER CODE BEGIN 5 */
+  switch(cmd)
+  {
+    case CDC_SEND_ENCAPSULATED_COMMAND:
+
+    break;
+
+    case CDC_GET_ENCAPSULATED_RESPONSE:
+
+    break;
+
+    case CDC_SET_COMM_FEATURE:
+
+    break;
+
+    case CDC_GET_COMM_FEATURE:
+
+    break;
+
+    case CDC_CLEAR_COMM_FEATURE:
+
+    break;
+
+  /*******************************************************************************/
+  /* Line Coding Structure                                                       */
+  /*-----------------------------------------------------------------------------*/
+  /* Offset | Field       | Size | Value  | Description                          */
+  /* 0      | dwDTERate   |   4  | Number |Data terminal rate, in bits per second*/
+  /* 4      | bCharFormat |   1  | Number | Stop bits                            */
+  /*                                        0 - 1 Stop bit                       */
+  /*                                        1 - 1.5 Stop bits                    */
+  /*                                        2 - 2 Stop bits                      */
+  /* 5      | bParityType |  1   | Number | Parity                               */
+  /*                                        0 - None                             */
+  /*                                        1 - Odd                              */
+  /*                                        2 - Even                             */
+  /*                                        3 - Mark                             */
+  /*                                        4 - Space                            */
+  /* 6      | bDataBits  |   1   | Number Data bits (5, 6, 7, 8 or 16).          */
+  /*******************************************************************************/
+    case CDC_SET_LINE_CODING:
+
+    break;
+
+    case CDC_GET_LINE_CODING:
+
+    break;
+
+    case CDC_SET_CONTROL_LINE_STATE:
+
+    break;
+
+    case CDC_SEND_BREAK:
+
+    break;
+
+  default:
+    break;
+  }
+
+  return (USBD_OK);
+  /* USER CODE END 5 */
+}
+
+/**
+  * @brief  Data received over USB OUT endpoint are sent over CDC interface
+  *         through this function.
+  *
+  *         @note
+  *         This function will block any OUT packet reception on USB endpoint
+  *         untill exiting this function. If you exit this function before transfer
+  *         is complete on CDC interface (ie. using DMA controller) it will result
+  *         in receiving more data while previous ones are still not sent.
+  *
+  * @param  Buf: Buffer of data to be received
+  * @param  Len: Number of data received (in bytes)
+  * @retval Result of the operation: USBD_OK if all operations are OK else USBD_FAIL
+  */
+static int8_t CDC_Receive_FS(uint8_t* Buf, uint32_t *Len)
+{
+  /* USER CODE BEGIN 6 */
+  USBD_CDC_SetRxBuffer(&Solo_USBD_Device, &Buf[0]);
+  USBD_CDC_ReceivePacket(&Solo_USBD_Device);
+  return (USBD_OK);
+  /* USER CODE END 6 */
+}
+
+/**
+  * @brief  CDC_Transmit_FS
+  *         Data to send over USB IN endpoint are sent over CDC interface
+  *         through this function.
+  *         @note
+  *
+  *
+  * @param  Buf: Buffer of data to be sent
+  * @param  Len: Number of data to be sent (in bytes)
+  * @retval USBD_OK if all operations are OK else USBD_FAIL or USBD_BUSY
+  */
+uint8_t CDC_Transmit_FS(uint8_t* Buf, uint16_t Len)
+{
+  uint8_t result = USBD_OK;
+  /* USER CODE BEGIN 7 */
+  USBD_CDC_HandleTypeDef *hcdc = (USBD_CDC_HandleTypeDef*)Solo_USBD_Device.pClassData;
+  if (hcdc->TxState != 0){
+    return USBD_BUSY;
+  }
+  USBD_CDC_SetTxBuffer(&Solo_USBD_Device, Buf, Len);
+  result = USBD_CDC_TransmitPacket(&Solo_USBD_Device);
+  /* USER CODE END 7 */
+  return result;
+}
+
+/* USER CODE BEGIN PRIVATE_FUNCTIONS_IMPLEMENTATION */
+
+/* USER CODE END PRIVATE_FUNCTIONS_IMPLEMENTATION */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/targets/stm32l442/lib/usbd/usbd_cdc_if.h
+++ b/targets/stm32l442/lib/usbd/usbd_cdc_if.h
@@ -1,0 +1,158 @@
+/**
+  ******************************************************************************
+  * @file           : usbd_cdc_if.h
+  * @version        : v2.0_Cube
+  * @brief          : Header for usbd_cdc_if.c file.
+  ******************************************************************************
+  * This notice applies to any and all portions of this file
+  * that are not between comment pairs USER CODE BEGIN and
+  * USER CODE END. Other portions of this file, whether
+  * inserted by the user or by software development tools
+  * are owned by their respective copyright owners.
+  *
+  * Copyright (c) 2018 STMicroelectronics International N.V.
+  * All rights reserved.
+  *
+  * Redistribution and use in source and binary forms, with or without
+  * modification, are permitted, provided that the following conditions are met:
+  *
+  * 1. Redistribution of source code must retain the above copyright notice,
+  *    this list of conditions and the following disclaimer.
+  * 2. Redistributions in binary form must reproduce the above copyright notice,
+  *    this list of conditions and the following disclaimer in the documentation
+  *    and/or other materials provided with the distribution.
+  * 3. Neither the name of STMicroelectronics nor the names of other
+  *    contributors to this software may be used to endorse or promote products
+  *    derived from this software without specific written permission.
+  * 4. This software, including modifications and/or derivative works of this
+  *    software, must execute solely and exclusively on microcontroller or
+  *    microprocessor devices manufactured by or for STMicroelectronics.
+  * 5. Redistribution and use of this software other than as permitted under
+  *    this license is void and will automatically terminate your rights under
+  *    this license.
+  *
+  * THIS SOFTWARE IS PROVIDED BY STMICROELECTRONICS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS, IMPLIED OR STATUTORY WARRANTIES, INCLUDING, BUT NOT
+  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  * PARTICULAR PURPOSE AND NON-INFRINGEMENT OF THIRD PARTY INTELLECTUAL PROPERTY
+  * RIGHTS ARE DISCLAIMED TO THE FULLEST EXTENT PERMITTED BY LAW. IN NO EVENT
+  * SHALL STMICROELECTRONICS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+  * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+  * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+  * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __USBD_CDC_IF_H__
+#define __USBD_CDC_IF_H__
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "usbd_cdc.h"
+
+/* USER CODE BEGIN INCLUDE */
+
+/* USER CODE END INCLUDE */
+
+/** @addtogroup STM32_USB_OTG_DEVICE_LIBRARY
+  * @brief For Usb device.
+  * @{
+  */
+
+/** @defgroup USBD_CDC_IF USBD_CDC_IF
+  * @brief Usb VCP device module
+  * @{
+  */
+
+/** @defgroup USBD_CDC_IF_Exported_Defines USBD_CDC_IF_Exported_Defines
+  * @brief Defines.
+  * @{
+  */
+/* USER CODE BEGIN EXPORTED_DEFINES */
+
+/* USER CODE END EXPORTED_DEFINES */
+
+/**
+  * @}
+  */
+
+/** @defgroup USBD_CDC_IF_Exported_Types USBD_CDC_IF_Exported_Types
+  * @brief Types.
+  * @{
+  */
+
+/* USER CODE BEGIN EXPORTED_TYPES */
+
+/* USER CODE END EXPORTED_TYPES */
+
+/**
+  * @}
+  */
+
+/** @defgroup USBD_CDC_IF_Exported_Macros USBD_CDC_IF_Exported_Macros
+  * @brief Aliases.
+  * @{
+  */
+
+/* USER CODE BEGIN EXPORTED_MACRO */
+
+/* USER CODE END EXPORTED_MACRO */
+
+/**
+  * @}
+  */
+
+/** @defgroup USBD_CDC_IF_Exported_Variables USBD_CDC_IF_Exported_Variables
+  * @brief Public variables.
+  * @{
+  */
+
+/** CDC Interface callback. */
+extern USBD_CDC_ItfTypeDef USBD_Interface_fops_FS;
+
+/* USER CODE BEGIN EXPORTED_VARIABLES */
+
+/* USER CODE END EXPORTED_VARIABLES */
+
+/**
+  * @}
+  */
+
+/** @defgroup USBD_CDC_IF_Exported_FunctionsPrototype USBD_CDC_IF_Exported_FunctionsPrototype
+  * @brief Public functions declaration.
+  * @{
+  */
+
+uint8_t CDC_Transmit_FS(uint8_t* Buf, uint16_t Len);
+
+/* USER CODE BEGIN EXPORTED_FUNCTIONS */
+
+/* USER CODE END EXPORTED_FUNCTIONS */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __USBD_CDC_IF_H__ */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/targets/stm32l442/lib/usbd/usbd_composite.c
+++ b/targets/stm32l442/lib/usbd/usbd_composite.c
@@ -226,7 +226,11 @@ static uint8_t USBD_Composite_Setup (USBD_HandleTypeDef *pdev, USBD_SetupReqType
     int i;
     switch (req->bmRequest & USB_REQ_TYPE_MASK) {
         case USB_REQ_TYPE_CLASS :
-            return USBD_Classes[req->wIndex]->Setup(pdev, req);
+            if (req->wIndex < NUM_INTERFACES)
+                return USBD_Classes[req->wIndex]->Setup(pdev, req);
+            else
+                return USBD_FAIL;
+
 
         case USB_REQ_TYPE_STANDARD:
             switch (req->bRequest) {
@@ -242,7 +246,10 @@ static uint8_t USBD_Composite_Setup (USBD_HandleTypeDef *pdev, USBD_SetupReqType
 
         case USB_REQ_GET_INTERFACE :
         case USB_REQ_SET_INTERFACE :
-            return USBD_Classes[req->wIndex]->Setup(pdev, req);
+            if (req->wIndex < NUM_INTERFACES)
+                return USBD_Classes[req->wIndex]->Setup(pdev, req);
+            else
+                return USBD_FAIL;
         }
     }
     return USBD_OK;

--- a/targets/stm32l442/lib/usbd/usbd_composite.c
+++ b/targets/stm32l442/lib/usbd/usbd_composite.c
@@ -1,0 +1,313 @@
+#include "usbd_composite.h"
+#include "usbd_desc.h"
+#include "usbd_hid.h"
+#include "usbd_cdc.h"
+#include "usbd_ctlreq.h"
+
+static uint8_t USBD_Composite_Init (USBD_HandleTypeDef *pdev, uint8_t cfgidx);
+
+static uint8_t USBD_Composite_DeInit (USBD_HandleTypeDef *pdev, uint8_t cfgidx);
+
+static uint8_t USBD_Composite_Setup (USBD_HandleTypeDef *pdev, USBD_SetupReqTypedef *req);
+
+static uint8_t USBD_Composite_DataIn (USBD_HandleTypeDef *pdev, uint8_t epnum);
+
+static uint8_t USBD_Composite_DataOut (USBD_HandleTypeDef *pdev, uint8_t epnum);
+
+static uint8_t USBD_Composite_EP0_RxReady (USBD_HandleTypeDef *pdev);
+
+static uint8_t *USBD_Composite_GetFSCfgDesc (uint16_t *length);
+
+static uint8_t *USBD_Composite_GetHSCfgDesc (uint16_t *length);
+
+static uint8_t *USBD_Composite_GetOtherSpeedCfgDesc (uint16_t *length);
+
+static uint8_t *USBD_Composite_GetOtherSpeedCfgDesc (uint16_t *length);
+
+static uint8_t *USBD_Composite_GetDeviceQualifierDescriptor (uint16_t *length);
+
+#define NUM_INTERFACES                      2
+
+#if NUM_INTERFACES>1
+#define COMPOSITE_CDC_HID_DESCRIPTOR_SIZE   (90)
+#else
+#define COMPOSITE_CDC_HID_DESCRIPTOR_SIZE   (41)
+#endif
+
+#define HID_INTF_NUM                        0
+#define CDC_INTF_NUM                        1
+__ALIGN_BEGIN uint8_t COMPOSITE_CDC_HID_DESCRIPTOR[COMPOSITE_CDC_HID_DESCRIPTOR_SIZE] __ALIGN_END =
+  {
+  /*Configuration Descriptor*/
+  0x09,   /* bLength: Configuration Descriptor size */
+  USB_DESC_TYPE_CONFIGURATION,      /* bDescriptorType: Configuration */
+  COMPOSITE_CDC_HID_DESCRIPTOR_SIZE,                /* wTotalLength:no of returned bytes */
+  0x00,
+  NUM_INTERFACES,   /* bNumInterfaces: 1 interface */
+  0x01,   /* bConfigurationValue: Configuration value */
+  0x00,   /* iConfiguration: Index of string descriptor describing the configuration */
+  0x80,   /* bmAttributes: self powered */
+  0x32,   /* MaxPower 100 mA */
+
+  /*---------------------------------------------------------------------------*/
+
+  /*     */
+  /* HID */
+  /*     */
+
+  /************** Descriptor of Joystick Mouse interface ****************/
+  0x09,         /*bLength: Interface Descriptor size*/
+  USB_DESC_TYPE_INTERFACE,/*bDescriptorType: Interface descriptor type*/
+  HID_INTF_NUM,         /*bInterfaceNumber: Number of Interface*/
+  0x00,         /*bAlternateSetting: Alternate setting*/
+  0x02,         /*bNumEndpoints*/
+  0x03,         /*bInterfaceClass: HID*/
+  0x00,         /*bInterfaceSubClass : 1=BOOT, 0=no boot*/
+  0x00,         /*nInterfaceProtocol : 0=none, 1=keyboard, 2=mouse*/
+  2,            /*iInterface: Index of string descriptor*/
+  /******************** Descriptor of Joystick Mouse HID ********************/
+  0x09,         /*bLength: HID Descriptor size*/
+  HID_DESCRIPTOR_TYPE, /*bDescriptorType: HID*/
+  0x11,         /*bcdHID: HID Class Spec release number*/
+  0x01,
+  0x00,         /*bCountryCode: Hardware target country*/
+  0x01,         /*bNumDescriptors: Number of HID class descriptors to follow*/
+  0x22,         /*bDescriptorType*/
+  HID_FIDO_REPORT_DESC_SIZE,/*wItemLength: Total length of Report descriptor*/
+  0,
+  /******************** Descriptor of Mouse endpoint ********************/
+  0x07,          /*bLength: Endpoint Descriptor size*/
+  USB_DESC_TYPE_ENDPOINT, /*bDescriptorType:*/
+  HID_EPIN_ADDR,     /*bEndpointAddress: Endpoint Address (IN)*/
+  0x03,          /*bmAttributes: Interrupt endpoint*/
+  HID_EPIN_SIZE, /*wMaxPacketSize: 4 Byte max */
+  0x00,
+  HID_BINTERVAL,          /*bInterval: Polling Interval */
+
+  0x07,          /*bLength: Endpoint Descriptor size*/
+  USB_DESC_TYPE_ENDPOINT, /*bDescriptorType:*/
+  HID_EPOUT_ADDR,     /*bEndpointAddress: Endpoint Address (IN)*/
+  0x03,          /*bmAttributes: Interrupt endpoint*/
+  HID_EPOUT_SIZE, /*wMaxPacketSize: 4 Byte max */
+  0x00,
+  HID_BINTERVAL,          /*bInterval: Polling Interval */
+
+
+
+#if NUM_INTERFACES>1
+
+    /*     */
+    /* CDC */
+    /*     */
+
+
+  /*Interface Descriptor */
+  0x09,   /* bLength: Interface Descriptor size */
+  USB_DESC_TYPE_INTERFACE,  /* bDescriptorType: Interface */
+  /* Interface descriptor type */
+/*!*/  CDC_INTF_NUM,   /* bInterfaceNumber: Number of Interface */
+  0x00,   /* bAlternateSetting: Alternate setting */
+  0x03,   /* bNumEndpoints: 3 endpoints used */
+  0x02,   /* bInterfaceClass: Communication Interface Class */
+  0x02,   /* bInterfaceSubClass: Abstract Control Model */
+  0x01,   /* bInterfaceProtocol: Common AT commands */
+  0x00,   /* iInterface: */
+
+  /*Header Functional Descriptor*/
+  0x05,   /* bLength: Endpoint Descriptor size */
+  0x24,   /* bDescriptorType: CS_INTERFACE */
+  0x00,   /* bDescriptorSubtype: Header Func Desc */
+  0x10,   /* bcdCDC: spec release number */
+  0x01,
+
+  /*Call Management Functional Descriptor*/
+  0x05,   /* bFunctionLength */
+  0x24,   /* bDescriptorType: CS_INTERFACE */
+  0x01,   /* bDescriptorSubtype: Call Management Func Desc */
+  0x00,   /* bmCapabilities: D0+D1 */
+/*!*/  CDC_INTF_NUM,   /* bDataInterface: 0 */
+
+  /*ACM Functional Descriptor*/
+  0x04,   /* bFunctionLength */
+  0x24,   /* bDescriptorType: CS_INTERFACE */
+  0x02,   /* bDescriptorSubtype: Abstract Control Management desc */
+  0x02,   /* bmCapabilities */
+
+  /*Union Functional Descriptor*/
+  0x05,   /* bFunctionLength */
+  0x24,   /* bDescriptorType: CS_INTERFACE */
+  0x06,   /* bDescriptorSubtype: Union func desc */
+/*!*/  CDC_INTF_NUM,   /* bMasterInterface: Communication class interface */
+/*!*/  CDC_INTF_NUM,   /* bSlaveInterface0: Data Class Interface */
+
+  /*Endpoint 2 Descriptor*/
+  0x07,                           /* bLength: Endpoint Descriptor size */
+  USB_DESC_TYPE_ENDPOINT,   /* bDescriptorType: Endpoint */
+  CDC_CMD_EP,                     /* bEndpointAddress */
+  0x03,                           /* bmAttributes: Interrupt */
+  LOBYTE(CDC_CMD_PACKET_SIZE),     /* wMaxPacketSize: */
+  HIBYTE(CDC_CMD_PACKET_SIZE),
+  0x10,                           /* bInterval: */
+
+  /*Endpoint OUT Descriptor*/
+  0x07,   /* bLength: Endpoint Descriptor size */
+  USB_DESC_TYPE_ENDPOINT,      /* bDescriptorType: Endpoint */
+  CDC_OUT_EP,                        /* bEndpointAddress */
+  0x02,                              /* bmAttributes: Bulk */
+  LOBYTE(CDC_DATA_FS_MAX_PACKET_SIZE),  /* wMaxPacketSize: */
+  HIBYTE(CDC_DATA_FS_MAX_PACKET_SIZE),
+  0x00,                              /* bInterval: ignore for Bulk transfer */
+
+  /*Endpoint IN Descriptor*/
+  0x07,   /* bLength: Endpoint Descriptor size */
+  USB_DESC_TYPE_ENDPOINT,      /* bDescriptorType: Endpoint */
+  CDC_IN_EP,                         /* bEndpointAddress */
+  0x02,                              /* bmAttributes: Bulk */
+  LOBYTE(CDC_DATA_FS_MAX_PACKET_SIZE),  /* wMaxPacketSize: */
+  HIBYTE(CDC_DATA_FS_MAX_PACKET_SIZE),
+  0x00,                               /* bInterval: ignore for Bulk transfer */
+
+#endif
+};
+
+
+USBD_ClassTypeDef USBD_Composite =
+{
+  USBD_Composite_Init,
+  USBD_Composite_DeInit,
+  USBD_Composite_Setup,
+  NULL, //TODO
+  USBD_Composite_EP0_RxReady,
+  USBD_Composite_DataIn,
+  USBD_Composite_DataOut,
+  NULL, //TODO
+  NULL, //TODO
+  NULL, //TODO
+  USBD_Composite_GetHSCfgDesc,
+  USBD_Composite_GetFSCfgDesc,
+  USBD_Composite_GetOtherSpeedCfgDesc,
+  USBD_Composite_GetDeviceQualifierDescriptor,
+};
+
+static USBD_ClassTypeDef *USBD_Classes[MAX_CLASSES];
+
+int in_endpoint_to_class[MAX_ENDPOINTS];
+
+int out_endpoint_to_class[MAX_ENDPOINTS];
+
+void USBD_Composite_Set_Classes(USBD_ClassTypeDef *class0, USBD_ClassTypeDef *class1) {
+    USBD_Classes[0] = class0;
+    USBD_Classes[1] = class1;
+}
+
+static uint8_t USBD_Composite_Init (USBD_HandleTypeDef *pdev, uint8_t cfgidx) {
+    int i;
+    for(i = 0; i < NUM_INTERFACES; i++) {
+        if (USBD_Classes[i]->Init(pdev, cfgidx) != USBD_OK) {
+            return USBD_FAIL;
+        }
+    }
+
+    return USBD_OK;
+}
+
+static uint8_t  USBD_Composite_DeInit (USBD_HandleTypeDef *pdev, uint8_t cfgidx) {
+    int i;
+    for(int i = 0; i < NUM_INTERFACES; i++) {
+        if (USBD_Classes[i]->DeInit(pdev, cfgidx) != USBD_OK) {
+            return USBD_FAIL;
+        }
+    }
+
+  return USBD_OK;
+}
+
+static uint8_t USBD_Composite_Setup (USBD_HandleTypeDef *pdev, USBD_SetupReqTypedef *req) {
+    int i;
+    switch (req->bmRequest & USB_REQ_TYPE_MASK) {
+        case USB_REQ_TYPE_CLASS :
+            return USBD_Classes[req->wIndex]->Setup(pdev, req);
+
+        case USB_REQ_TYPE_STANDARD:
+            switch (req->bRequest) {
+
+                case USB_REQ_GET_DESCRIPTOR :
+                    for(i = 0; i < NUM_INTERFACES; i++) {
+                        if (USBD_Classes[i]->Setup(pdev, req) != USBD_OK) {
+                            return USBD_FAIL;
+                        }
+                    }
+
+                break;
+
+        case USB_REQ_GET_INTERFACE :
+        case USB_REQ_SET_INTERFACE :
+            return USBD_Classes[req->wIndex]->Setup(pdev, req);
+        }
+    }
+    return USBD_OK;
+}
+
+static uint8_t USBD_Composite_DataIn (USBD_HandleTypeDef *pdev, uint8_t epnum) {
+    int i;
+
+    i = in_endpoint_to_class[epnum];
+
+    return USBD_Classes[i]->DataIn(pdev, epnum);
+}
+
+static uint8_t USBD_Composite_DataOut (USBD_HandleTypeDef *pdev, uint8_t epnum) {
+  int i;
+
+  i = out_endpoint_to_class[epnum];
+
+  return USBD_Classes[i]->DataOut(pdev, epnum);
+
+}
+
+static uint8_t USBD_Composite_EP0_RxReady (USBD_HandleTypeDef *pdev) {
+    int i;
+    for(i = 0; i < NUM_INTERFACES; i++) {
+        if (USBD_Classes[i]->EP0_RxReady != NULL) {
+            if (USBD_Classes[i]->EP0_RxReady(pdev) != USBD_OK) {
+                return USBD_FAIL;
+            }
+        }
+    }
+    return USBD_OK;
+}
+
+static uint8_t  *USBD_Composite_GetFSCfgDesc (uint16_t *length) {
+    *length = COMPOSITE_CDC_HID_DESCRIPTOR_SIZE;
+    return COMPOSITE_CDC_HID_DESCRIPTOR;
+}
+
+static uint8_t  *USBD_Composite_GetHSCfgDesc (uint16_t *length) {
+    *length = COMPOSITE_CDC_HID_DESCRIPTOR_SIZE;
+    return COMPOSITE_CDC_HID_DESCRIPTOR;
+}
+
+static uint8_t  *USBD_Composite_GetOtherSpeedCfgDesc (uint16_t *length) {
+    *length = COMPOSITE_CDC_HID_DESCRIPTOR_SIZE;
+    return COMPOSITE_CDC_HID_DESCRIPTOR;
+}
+
+/* USB Standard Device Descriptor */
+__ALIGN_BEGIN static uint8_t USBD_Composite_DeviceQualifierDesc[USB_LEN_DEV_QUALIFIER_DESC] __ALIGN_END =
+{
+  USB_LEN_DEV_QUALIFIER_DESC,
+  USB_DESC_TYPE_DEVICE_QUALIFIER,
+  0x00,
+  0x02,
+  0x00,
+  0x00,
+  0x00,
+  0x40,
+  0x01,
+  0x00,
+};
+
+uint8_t  *USBD_Composite_GetDeviceQualifierDescriptor (uint16_t *length) {
+  *length = sizeof (USBD_Composite_DeviceQualifierDesc);
+  return USBD_Composite_DeviceQualifierDesc;
+}

--- a/targets/stm32l442/lib/usbd/usbd_composite.h
+++ b/targets/stm32l442/lib/usbd/usbd_composite.h
@@ -1,0 +1,26 @@
+#ifndef __USB_COMPOSITE_H
+#define __USB_COMPOSITE_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#include "usbd_ioreq.h"
+
+#define MAX_CLASSES 4
+
+#define MAX_ENDPOINTS 16
+
+extern USBD_ClassTypeDef USBD_Composite;
+
+extern int in_endpoint_to_class[MAX_ENDPOINTS];
+
+extern int out_endpoint_to_class[MAX_ENDPOINTS];
+
+void USBD_Composite_Set_Classes(USBD_ClassTypeDef *class0, USBD_ClassTypeDef *class1);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/targets/stm32l442/lib/usbd/usbd_conf.c
+++ b/targets/stm32l442/lib/usbd/usbd_conf.c
@@ -247,10 +247,20 @@ USBD_StatusTypeDef USBD_LL_Init(USBD_HandleTypeDef *pdev)
     _Error_Handler(__FILE__, __LINE__);
   }
 
+  // control
   HAL_PCDEx_PMAConfig((PCD_HandleTypeDef*)pdev->pData , 0x00 , PCD_SNG_BUF, 0x18);
   HAL_PCDEx_PMAConfig((PCD_HandleTypeDef*)pdev->pData , 0x80 , PCD_SNG_BUF, 0x58);
+
+  // HID
   HAL_PCDEx_PMAConfig((PCD_HandleTypeDef*)pdev->pData , 0x01 , PCD_SNG_BUF, 0x98);
   HAL_PCDEx_PMAConfig((PCD_HandleTypeDef*)pdev->pData , 0x81 , PCD_SNG_BUF, 0xd8);
+
+  // CDC / uart
+  HAL_PCDEx_PMAConfig((PCD_HandleTypeDef*)pdev->pData , 0x02 , PCD_SNG_BUF, 0xd8 + 64);  // data OUT
+  HAL_PCDEx_PMAConfig((PCD_HandleTypeDef*)pdev->pData , 0x82 , PCD_SNG_BUF, 0xd8 + 64*2);  // data IN
+  HAL_PCDEx_PMAConfig((PCD_HandleTypeDef*)pdev->pData , 0x83 , PCD_SNG_BUF, 0xd8 + 64*3);  // commands
+
+
   return USBD_OK;
 }
 

--- a/targets/stm32l442/lib/usbd/usbd_hid.c
+++ b/targets/stm32l442/lib/usbd/usbd_hid.c
@@ -112,10 +112,17 @@ USBD_ClassTypeDef  USBD_HID =
   NULL, /*SOF */
   NULL,
   NULL,
-  USBD_HID_GetFSCfgDesc,
-  USBD_HID_GetFSCfgDesc,
-  USBD_HID_GetFSCfgDesc,
-  USBD_HID_GetDeviceQualifierDesc,
+
+
+
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  // USBD_HID_GetFSCfgDesc,
+  // USBD_HID_GetFSCfgDesc,
+  // USBD_HID_GetFSCfgDesc,
+  // USBD_HID_GetDeviceQualifierDesc,
 };
 
 #define USBD_HID_CfgHSDesc USBD_HID_OtherSpeedCfgDesc
@@ -388,6 +395,7 @@ static uint8_t  USBD_HID_Setup (USBD_HandleTypeDef *pdev,
       {
         len = MIN(HID_FIDO_REPORT_DESC_SIZE , req->wLength);
         pbuf = HID_MOUSE_ReportDesc;
+        printf1(TAG_GREEN,"get report desc\r\n");
       }
       else if(req->wValue >> 8 == HID_DESCRIPTOR_TYPE)
       {

--- a/targets/stm32l442/src/app.h
+++ b/targets/stm32l442/src/app.h
@@ -1,21 +1,21 @@
 /*
  * Copyright (C) 2018 SoloKeys, Inc. <https://solokeys.com/>
- * 
+ *
  * This file is part of Solo.
- * 
+ *
  * Solo is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solo is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with Solo.  If not, see <https://www.gnu.org/licenses/>
- * 
+ *
  * This code is available under licenses for commercial use.
  * Please contact SoloKeys for more information.
  */
@@ -71,6 +71,6 @@ void hw_init(void);
 #define SOLO_BUTTON_PIN         LL_GPIO_PIN_0
 
 #define SKIP_BUTTON_CHECK_WITH_DELAY        0
-#define SKIP_BUTTON_CHECK_FAST              0
+#define SKIP_BUTTON_CHECK_FAST              1
 
 #endif

--- a/targets/stm32l442/src/device.c
+++ b/targets/stm32l442/src/device.c
@@ -184,15 +184,6 @@ void heartbeat()
     uint8_t b = (LED_INIT_VALUE >> 0) & 0xff;
     int but = IS_BUTTON_PRESSED();
 
-    ///
-    // char msg[] = "hello cdc\r\n";
-    // int ret;
-    // if ((ret=CDC_Transmit_FS(msg, sizeof(msg))) != USBD_OK)
-    // {
-    //     printf1(TAG_RED,"cdc returned %d\r\n", ret);
-    // }
-
-
     if (state)
     {
         val--;

--- a/targets/stm32l442/src/device.c
+++ b/targets/stm32l442/src/device.c
@@ -1,21 +1,21 @@
 /*
  * Copyright (C) 2018 SoloKeys, Inc. <https://solokeys.com/>
- * 
+ *
  * This file is part of Solo.
- * 
+ *
  * Solo is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solo is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with Solo.  If not, see <https://www.gnu.org/licenses/>
- * 
+ *
  * This code is available under licenses for commercial use.
  * Please contact SoloKeys for more information.
  */
@@ -40,7 +40,7 @@
 #include "crypto.h"
 #include "memory_layout.h"
 #include "stm32l4xx_ll_iwdg.h"
-
+#include "usbd_cdc_if.h"
 
 uint32_t __90_ms = 0;
 uint32_t __device_status = 0;
@@ -183,6 +183,15 @@ void heartbeat()
     uint8_t g = (LED_INIT_VALUE >> 8) & 0xff;
     uint8_t b = (LED_INIT_VALUE >> 0) & 0xff;
     int but = IS_BUTTON_PRESSED();
+
+    ///
+    // char msg[] = "hello cdc\r\n";
+    // int ret;
+    // if ((ret=CDC_Transmit_FS(msg, sizeof(msg))) != USBD_OK)
+    // {
+    //     printf1(TAG_RED,"cdc returned %d\r\n", ret);
+    // }
+
 
     if (state)
     {

--- a/targets/stm32l442/src/init.c
+++ b/targets/stm32l442/src/init.c
@@ -1,21 +1,21 @@
 /*
  * Copyright (C) 2018 SoloKeys, Inc. <https://solokeys.com/>
- * 
+ *
  * This file is part of Solo.
- * 
+ *
  * Solo is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solo is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with Solo.  If not, see <https://www.gnu.org/licenses/>
- * 
+ *
  * This code is available under licenses for commercial use.
  * Please contact SoloKeys for more information.
  */
@@ -40,6 +40,9 @@
 #include "usbd_core.h"
 #include "usbd_desc.h"
 #include "usbd_hid.h"
+#include "usbd_cdc.h"
+#include "usbd_composite.h"
+#include "usbd_cdc_if.h"
 #include "device.h"
 #include APP_CONFIG
 
@@ -205,8 +208,22 @@ void usb_init()
     // Enable USB Clock
     SET_BIT(RCC->APB1ENR1, RCC_APB1ENR1_USBFSEN);
 
+
+    USBD_Composite_Set_Classes(&USBD_HID, &USBD_CDC);
+    // USBD_Composite_Set_Classes(&USBD_CDC, &USBD_CDC);
+    in_endpoint_to_class[HID_EPIN_ADDR & 0x7F] = 0;
+    out_endpoint_to_class[HID_EPOUT_ADDR & 0x7F] = 0;
+
+    in_endpoint_to_class[CDC_IN_EP & 0x7F] = 1;
+    out_endpoint_to_class[CDC_OUT_EP & 0x7F] = 1;
+
     USBD_Init(&Solo_USBD_Device, &Solo_Desc, 0);
-    USBD_RegisterClass(&Solo_USBD_Device, &USBD_HID);
+    USBD_RegisterClass(&Solo_USBD_Device, &USBD_Composite);
+    // USBD_RegisterClass(&Solo_USBD_Device, &USBD_HID);
+    //
+    // USBD_RegisterClass(&Solo_USBD_Device, &USBD_CDC);
+    USBD_CDC_RegisterInterface(&Solo_USBD_Device, &USBD_Interface_fops_FS);
+
     USBD_Start(&Solo_USBD_Device);
 }
 

--- a/targets/stm32l442/src/redirect.c
+++ b/targets/stm32l442/src/redirect.c
@@ -1,25 +1,26 @@
 /*
  * Copyright (C) 2018 SoloKeys, Inc. <https://solokeys.com/>
- * 
+ *
  * This file is part of Solo.
- * 
+ *
  * Solo is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solo is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with Solo.  If not, see <https://www.gnu.org/licenses/>
- * 
+ *
  * This code is available under licenses for commercial use.
  * Please contact SoloKeys for more information.
  */
 #include "stm32l4xx_ll_usart.h"
+#include "usbd_cdc_if.h"
 
 #include APP_CONFIG
 #include "fifo.h"
@@ -42,11 +43,15 @@ void _putchar(char c)
 int _write (int fd, const void *buf, long int len)
 {
     uint8_t * data = (uint8_t *) buf;
+
+    // Send out USB serial
+    CDC_Transmit_FS(data, len);
+
+    // Send out UART serial
     while(len--)
     {
         _putchar(*data++);
     }
     return 0;
-
 }
 #endif

--- a/tools/serial_monitor.py
+++ b/tools/serial_monitor.py
@@ -1,4 +1,26 @@
 #!/usr/bin/python
+#
+# Copyright (C) 2018 SoloKeys, Inc. <https://solokeys.com/>
+#
+# This file is part of Solo.
+#
+# Solo is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Solo is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Solo.  If not, see <https://www.gnu.org/licenses/>
+#
+# This code is available under licenses for commercial use.
+# Please contact SoloKeys for more information.
+#
+
 # This is a basic, cross-platfrom serial emulator.
 # It will automatically try to reconnect to a serial port that disconnects.
 # Ideal for development with Solo.

--- a/tools/serial_monitor.py
+++ b/tools/serial_monitor.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python
+# This is a basic, cross-platfrom serial emulator.
+# It will automatically try to reconnect to a serial port that disconnects.
+# Ideal for development with Solo.
+#
+# Requires pySerial
+#
+import sys,time
+import serial
+
+if len(sys.argv) != 2:
+    print(
+"""
+usage: %s <serial-port>
+      * <serial-port> will look like COM10 or /dev/ttyACM0 or something.
+      * baud is 115200.
+""" % sys.argv[0])
+    sys.exit(1)
+
+port = sys.argv[1]
+
+ser = serial.Serial(port,115200,timeout=.05)
+
+def reconnect():
+    while(1):
+        time.sleep(0.02)
+        try:
+            ser = serial.Serial(port,115200,timeout=.05)
+            return ser
+        except serial.SerialException:
+            pass
+while 1:
+    try:
+        d = ser.read(1)
+    except serial.SerialException:
+        print('reconnecting...')
+        ser = reconnect()
+        print('done')
+    sys.stdout.buffer.write(d)
+    sys.stdout.flush()


### PR DESCRIPTION
This adds the CDC usb profile to Solo (USB serial).  All debugging messages will be passed to it in addition to the real uart.  I wanted to add this to make it easy to do development using only a USB port.  Messages can be viewed using any serial terminal emulator.

One issue is that any debug messages at startup will usually be lost since there's a bit of a delay between when Solo connects and when a serial program can connect to it.  

